### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   find:
     name: Find add-ons


### PR DESCRIPTION
Potential fix for [https://github.com/SpechtLabs/homeassistant-addons/security/code-scanning/1](https://github.com/SpechtLabs/homeassistant-addons/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves checking out code and running a linter, it only requires `contents: read` permissions. This will restrict the `GITHUB_TOKEN` to read-only access to the repository contents, ensuring no unnecessary write permissions are granted.

The `permissions` block will be added at the root level of the workflow to apply to all jobs (`find` and `lint`). This avoids redundancy and ensures consistent permissions across the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
