### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,8 @@
 name: Lint
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/SpechtLabs/homeassistant-addons/security/code-scanning/2](https://github.com/SpechtLabs/homeassistant-addons/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow primarily performs read-only operations (e.g., checking out code and running a linter), the `contents: read` permission is sufficient. This block should be added at the root level of the workflow to apply to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
