### PR TITLE
fix(grafana_alloy): chmod +x the alloy binary after extraction

### DIFF
--- a/grafana_alloy/CHANGELOG.md
+++ b/grafana_alloy/CHANGELOG.md
@@ -1,5 +1,9 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 0.2.1
+
+- Fix add-on failing to start (`/usr/bin/grafana-alloy: Permission denied`, exit 126): the Alloy v1.17.0 release zip ships the binary without the executable bit, so `chmod +x` it after extraction.
+
 ## 0.2.0
 
 - Per-signal configuration: `loki_endpoint`, `mimir_endpoint` and `tempo_endpoint` are now independent and optional — only configured signals are wired up.

--- a/grafana_alloy/Dockerfile
+++ b/grafana_alloy/Dockerfile
@@ -21,6 +21,7 @@ RUN apk --update add libc6-compat && rm -rf /var/cache/apk/*
 RUN cd /tmp && \
     curl -sSLf -o alloy.zip "https://github.com/grafana/alloy/releases/download/${ALLOY_VERSION}/alloy-linux-${BUILD_ARCH//aarch64/arm64}.zip" && \
     unzip alloy.zip && mv alloy-linux-* /usr/bin/grafana-alloy && \
+    chmod +x /usr/bin/grafana-alloy && \
     rm alloy.zip
 
 # Copy files for addon

--- a/grafana_alloy/config.yaml
+++ b/grafana_alloy/config.yaml
@@ -1,6 +1,6 @@
 name: "Grafana Alloy"
 description: "Send metrics, logs & traces to Grafana Cloud or your own Grafana observability stack"
-version: "0.2.0"
+version: "0.2.1"
 slug: "grafana_alloy"
 init: false
 arch:


### PR DESCRIPTION
## Goal

Fix the add-on crash-looping on start with `/usr/bin/grafana-alloy: Permission denied` (exit 126) after the v1.17.0 bump.

## Rationale

The Alloy v1.17.0 release zip stores the binary as `-rw-r--r--`, without the executable bit:

```
$ unzip -ZT alloy-linux-amd64.zip
-rw-r--r-- alloy-linux-amd64
```

The Dockerfile extracts and `mv`s it into place but never sets `+x`, so it relied on the archive carrying the exec bit (v1.7.5 did; v1.17.0 does not). CI builds the image but never runs it, so this slipped through green checks.

## Changes

Add `chmod +x /usr/bin/grafana-alloy` right after the `mv` in the Dockerfile, so executability no longer depends on the archive's stored mode. Bumped to 0.2.1.